### PR TITLE
Adiciona suporte a limite de participantes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,8 @@ group :development, :test do
   gem 'foreman'
   gem 'byebug'
   gem 'factory_girl_rails', '~> 4.0'
+  gem 'pry-rails'
+  gem 'pry-byebug'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,13 +50,14 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    coderay (1.1.1)
+      term-ansicolor (~> 1.3)
+      thor (~> 0.19.1)
+      tins (>= 1.6.0, < 2)
     concurrent-ruby (1.0.2)
     coveralls (0.8.15)
       json (>= 1.8, < 3)
       simplecov (~> 0.12.0)
-      term-ansicolor (~> 1.3)
-      thor (~> 0.19.1)
-      tins (>= 1.6.0, < 2)
     daemons (1.2.4)
     database_cleaner (1.5.3)
     diff-lcs (1.2.5)
@@ -125,6 +126,15 @@ GEM
       json (~> 1.3)
       omniauth-oauth (~> 1.1)
     pg (0.19.0)
+    pry (0.10.4)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    pry-byebug (3.4.0)
+      byebug (~> 9.0)
+      pry (~> 0.10)
+    pry-rails (0.3.4)
+      pry (>= 0.9.10)
     rack (2.0.1)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -188,6 +198,7 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
+    slop (3.6.0)
     sprockets (3.7.0)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -234,6 +245,8 @@ DEPENDENCIES
   omniauth-github
   omniauth-twitter
   pg
+  pry-byebug
+  pry-rails
   rails (~> 5.0)
   rails-controller-testing
   rails-i18n
@@ -248,4 +261,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.13.1
+   1.13.5

--- a/app/controllers/dojos_controller.rb
+++ b/app/controllers/dojos_controller.rb
@@ -40,8 +40,14 @@ class DojosController < ApplicationController
   end
 
   def participate
-    @dojo.include_participant!(current_user)
-    redirect_to @dojo, notice: "Incluído na lista de participantes ;)"
+    begin
+      @dojo.include_participant!(current_user)
+      flash[:notice] = "Incluído na lista de participantes ;)"
+    rescue Dojoonde::ParticipantLimitError
+      flash[:alert] = t('helpers.dojos.participate_button.participate_reached_limit')
+    end
+
+    redirect_to @dojo
   end
 
   def quit
@@ -56,7 +62,7 @@ class DojosController < ApplicationController
 
   private
   def dojo_params
-    params.require(:dojo).permit(:day, :local, :gmaps_link, :info, :private)
+    params.require(:dojo).permit(:day, :local, :gmaps_link, :info, :private, :participant_limit)
   end
 
   def set_dojo

--- a/app/helpers/dojos_helper.rb
+++ b/app/helpers/dojos_helper.rb
@@ -1,8 +1,12 @@
 module DojosHelper
   def participate_button(user, dojo = @dojo)
-    user && user.participate?(dojo) ?
-      link_to(t('helpers.dojos.participate_button.participate_no'), quit_dojo_path(dojo), method: :put, class: "btn btn-danger btn-block") :
+    if dojo.has_participant?(user)
+      link_to(t('helpers.dojos.participate_button.participate_no'), quit_dojo_path(dojo), method: :put, class: "btn btn-danger btn-block")
+    elsif dojo.reached_limit?
+      content_tag(:div, t('helpers.dojos.participate_button.participate_reached_limit'), class: "well")
+    else
       link_to(t('helpers.dojos.participate_button.participate_yes'), participate_dojo_path(dojo), method: :put, class: "btn btn-success btn-block")
+    end
   end
 
   def gravatar_url(user, size=nil)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,9 +21,7 @@ class User < ActiveRecord::Base
   end
 
   def participate?(dojo)
-    present = false
-    dojo.participants.each { |participant| present = true if participant.user == self }
-    present
+    dojo.participants.find_by(user_id: id).present?
   end
 
   def can_manage?(dojo_id)

--- a/app/views/dojos/_form.html.erb
+++ b/app/views/dojos/_form.html.erb
@@ -28,6 +28,11 @@
   </div>
 
   <div class="control-group">
+    <%= f.label :participant_limit, class: "control-label" %>
+    <p class="controls"><%= f.text_field :participant_limit, class: "input-xxlarge" %></p>
+  </div>
+
+  <div class="control-group">
     <%= f.label :private, class: "control-label" %>
     <p class="controls"><%= f.check_box :private %></p>
   </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,7 +13,7 @@ module Dojoonde
     # -- all .rb files in that directory are automatically loaded.
 
     # Custom directories with classes and modules you want to be autoloadable.
-    # config.autoload_paths += %W(#{config.root}/extras)
+    config.autoload_paths += %W(#{config.root}/lib)
 
     # Activate observers that should always be running.
     # config.active_record.observers = :cacher, :garbage_collector, :forum_observer

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -4,10 +4,10 @@ pt-BR:
       default: "%d/%m/%Y %H:%Mh"
   activerecord:
     models:
-      user: 
+      user:
         one: "usuário"
         other: "usuários"
-      retrospective: 
+      retrospective:
         one: "retrospectiva"
         other: "retrospectivas"
       participant:
@@ -25,6 +25,7 @@ pt-BR:
         gmaps_link: "Link do Google Maps"
         info: "Outras Informações"
         private: "Privado?"
+        participant_limit: "Limite de participantes"
       retrospective:
         challenge: "Desafio"
         positive_points: "Pontos Positivos"
@@ -145,3 +146,4 @@ pt-BR:
       participate_button:
         participate_yes: "Eu vou!"
         participate_no: "Desistir :("
+        participate_reached_limit: "Limite de participação atingido! Mas não perca a esperança, talvez alguém desista. Volte mais tarde e tente novamente."

--- a/db/migrate/20161018121147_add_participant_limit_to_dojo.rb
+++ b/db/migrate/20161018121147_add_participant_limit_to_dojo.rb
@@ -1,0 +1,5 @@
+class AddParticipantLimitToDojo < ActiveRecord::Migration
+  def change
+    add_column :dojos, :participant_limit, :integer, nil: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,9 +11,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140718003544) do
+ActiveRecord::Schema.define(version: 20161018121147) do
 
-  create_table "authentications", force: true do |t|
+  create_table "authentications", force: :cascade do |t|
     t.string   "uid"
     t.string   "provider"
     t.integer  "user_id"
@@ -24,7 +24,7 @@ ActiveRecord::Schema.define(version: 20140718003544) do
   add_index "authentications", ["uid", "provider"], name: "index_authentications_on_uid_and_provider"
   add_index "authentications", ["user_id"], name: "index_authentications_on_user_id"
 
-  create_table "dojos", force: true do |t|
+  create_table "dojos", force: :cascade do |t|
     t.datetime "day"
     t.string   "local"
     t.text     "info"
@@ -32,10 +32,11 @@ ActiveRecord::Schema.define(version: 20140718003544) do
     t.integer  "user_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "private",    default: false
+    t.boolean  "private",           default: false
+    t.integer  "participant_limit", default: 0
   end
 
-  create_table "participants", force: true do |t|
+  create_table "participants", force: :cascade do |t|
     t.integer  "user_id"
     t.integer  "dojo_id"
     t.datetime "created_at"
@@ -45,7 +46,7 @@ ActiveRecord::Schema.define(version: 20140718003544) do
   add_index "participants", ["dojo_id"], name: "index_participants_on_dojo_id"
   add_index "participants", ["user_id"], name: "index_participants_on_user_id"
 
-  create_table "retrospectives", force: true do |t|
+  create_table "retrospectives", force: :cascade do |t|
     t.string   "challenge"
     t.text     "positive_points"
     t.text     "improvement_points"
@@ -56,7 +57,7 @@ ActiveRecord::Schema.define(version: 20140718003544) do
 
   add_index "retrospectives", ["dojo_id"], name: "index_retrospectives_on_dojo_id"
 
-  create_table "users", force: true do |t|
+  create_table "users", force: :cascade do |t|
     t.string   "name"
     t.string   "email"
     t.string   "password_digest"

--- a/lib/dojoonde/participant_limit_error.rb
+++ b/lib/dojoonde/participant_limit_error.rb
@@ -1,0 +1,1 @@
+class Dojoonde::ParticipantLimitError < StandardError; end

--- a/spec/controllers/dojos_controller_spec.rb
+++ b/spec/controllers/dojos_controller_spec.rb
@@ -58,4 +58,26 @@ describe DojosController, type: :controller do
       end
     end
   end
+
+  describe 'PUT participate' do
+    context 'when is not already a participant' do
+      it do
+        dojo = FactoryGirl.create(:dojo)
+        put :participate, params: { id: dojo }, session: credentials
+        expect(response).to redirect_to dojo_path(dojo)
+        expect(flash[:alert]).to be_nil
+      end
+    end
+
+    context 'when dojo has reached the limit of participants' do
+      it do
+        dojo = FactoryGirl.create(:dojo)
+        allow_any_instance_of(Dojo).to receive(:reached_limit?).and_return(true)
+
+        put :participate, params: { id: dojo }, session: credentials
+        expect(response).to redirect_to dojo_path(dojo)
+        expect(flash[:alert]).to eq I18n.t('helpers.dojos.participate_button.participate_reached_limit')
+      end
+    end
+  end
 end

--- a/spec/features/participants_spec.rb
+++ b/spec/features/participants_spec.rb
@@ -61,6 +61,7 @@ feature "participate of the dojo" do
 
     scenario "should participate of the dojo" do
       click_on "Eu vou!"
+      allow(user).to receive(:participate?).and_return(false)
       expect(current_path).to eq dojo_path(dojo)
       expect(page).to have_content "Desistir :("
       expect(page).to have_content "Incluído na lista de participantes ;)"

--- a/spec/helpers/dojos_helper_spec.rb
+++ b/spec/helpers/dojos_helper_spec.rb
@@ -11,9 +11,9 @@ describe DojosHelper, type: :helper do
     end
 
     it "displays participate button when user is not a participant" do
-      other = FactoryGirl.create(:user)
+      other_user = FactoryGirl.create(:user)
       correct_button = link_to("Eu vou!", participate_dojo_path(dojo), method: :put, class: "btn btn-success btn-block")
-      result = participate_button(other, dojo)
+      result = participate_button(other_user, dojo)
       expect(result).to eq(correct_button)
     end
 
@@ -21,6 +21,16 @@ describe DojosHelper, type: :helper do
       correct_button = link_to("Desistir :(", quit_dojo_path(dojo), method: :put, class: "btn btn-danger btn-block")
       result = participate_button(dojo.user, dojo)
       expect(result).to eq(correct_button)
+    end
+
+    it "displays participant limit message error" do
+      user = FactoryGirl.create(:user)
+      allow(dojo).to receive(:reached_limit?).and_return(true)
+      allow(user).to receive(:participate?).and_return(false)
+
+      message = content_tag(:div, t('helpers.dojos.participate_button.participate_reached_limit'), class: "well")
+      result = participate_button(user, dojo)
+      expect(result).to eq(message)
     end
   end
 


### PR DESCRIPTION
Adicionado suporte a limite de participantes conforme solicitado na issue #25 . A ideia é que seja possível limitar a participação no evento a um número determinado.

Ao atingir o limite de participantes não será mais possível se registrar
no evento.

Para que um evento não tenha limite, é só manter o valor `0`, qualquer valor acima de `0` é considerado um limitador.

Seguem prints para visualização.

### Cadastro do dojo:
![screen shot 2016-10-18 at 13 15 07](https://cloud.githubusercontent.com/assets/287685/19485062/9df8bae4-9538-11e6-91b5-48d1b64867ba.png)

### Quando atingir o limite
![screen shot 2016-10-18 at 13 14 49](https://cloud.githubusercontent.com/assets/287685/19485085/b749939c-9538-11e6-8401-51c900fbb1cc.png)


## OFF-TOPIC:

* Aproveitei para adicionar a gem [pry-rails](https://github.com/rweng/pry-rails) para auxiliar no desenvolvimento;
* Vi alguns pontos que seria interessante refatorar, principalmente envolvendo traduções;