### PR TITLE
Permite edição de dojo a partir da página do dojo

### DIFF
--- a/app/models/dojo.rb
+++ b/app/models/dojo.rb
@@ -43,6 +43,10 @@ class Dojo < ActiveRecord::Base
     participants.find_by(user_id: participant).present?
   end
 
+  def belongs_to?(_user)
+    user == _user
+  end
+
   private
   def day_cannot_be_in_the_past
     errors.add(:day, :cannot_be_in_the_past) if day.present? && day < Date.today

--- a/app/views/dojos/show.html.erb
+++ b/app/views/dojos/show.html.erb
@@ -25,7 +25,7 @@
     <% end %>
 
     <%= participate_button(current_user) %>
-    <br/>
+    <%= link_to("Editar Dojo", edit_dojo_path(@dojo, back_to: dojo_path(@dojo)), class: 'btn btn-warning btn-block') if @dojo.belongs_to?(current_user) %>
 
     <% unless @dojo.private? %>
       <strong><%= t('general.buttons.share') %></strong>

--- a/spec/models/dojo_spec.rb
+++ b/spec/models/dojo_spec.rb
@@ -152,4 +152,19 @@ describe Dojo do
       it { expect(dojo.to_s).to eq "[PRIVADO] #{day_formatted} - bla" }
     end
   end
+
+  describe "#belongs_to?" do
+    context "when user is dojo's owner" do
+      it do
+        expect(dojo.belongs_to?(dojo.user)).to be true
+      end
+    end
+
+    context "when user isn't dojo's owner" do
+      it do
+        other_user = FactoryGirl.create(:user, name: "Other guy", email: 'other_email-123@gmail.com')
+        expect(dojo.belongs_to?(other_user)).to be false
+      end
+    end
+  end
 end


### PR DESCRIPTION
Permite a edição de um dojo a partir da página do dojo quando o usuário
corrente é o dono. Resolução da issue #22 